### PR TITLE
Feat: elasticsearch dual write

### DIFF
--- a/docker-compose/compose-dev.infra.yml
+++ b/docker-compose/compose-dev.infra.yml
@@ -1,0 +1,48 @@
+name: palgoosam-infra
+services:
+  elastic:
+    build:
+      context: .
+      dockerfile: elasticsearch.custom.dockerfile
+    ports:
+      - 9200:9200
+    volumes:
+      - palgoosam-es:/usr/share/elasticsearch/data
+    environment:
+      # 아래 설정은 개발/테스트 환경에서 간단하게 테스트하기 위한 옵션
+      - discovery.type=single-node # 단일 노드
+      - xpack.security.enabled=false # 보안 설정
+      - xpack.security.http.ssl.enabled=false # 보안 설정
+    networks:
+      - Palgoosam
+
+  kibana:
+    image: docker.elastic.co/kibana/kibana:8.17.4
+    ports:
+      - 5601:5601
+    environment:
+      - ELASTICSEARCH_HOSTS=http://elastic:9200 # kibana가 통신할 Elasticsearch 주소
+    networks:
+      - Palgoosam
+    depends_on:
+      elastic:
+        condition: service_started
+
+  redis:
+    image: 'redis:8.0.6-alpine'
+    ports:
+      - '6379:6379'
+    volumes:
+      - palgoosam-redis:/data
+    networks:
+      - Palgoosam
+    environment:
+      TZ: 'Asia/Seoul'
+
+volumes:
+  palgoosam-es:
+  palgoosam-redis:
+
+networks:
+  Palgoosam:
+    driver: bridge

--- a/docker-compose/compose-dev.infra.yml
+++ b/docker-compose/compose-dev.infra.yml
@@ -39,6 +39,14 @@ services:
     environment:
       TZ: 'Asia/Seoul'
 
+  toxiproxy:
+    image: ghcr.io/shopify/toxiproxy
+    ports:
+      - "8474:8474"   # Toxiproxy 관리 API
+      - "9201:9201"   # ES 프록시 포트 (앱은 여기로 연결)
+    networks:
+      - Palgoosam
+
 volumes:
   palgoosam-es:
   palgoosam-redis:

--- a/docker-compose/elasticsearch.custom.dockerfile
+++ b/docker-compose/elasticsearch.custom.dockerfile
@@ -1,0 +1,3 @@
+FROM docker.elastic.co/elasticsearch/elasticsearch:8.17.4
+
+RUN elasticsearch-plugin install --batch analysis-nori

--- a/src/main/java/com/samyookgoo/palgoosam/auction/service/AuctionService.java
+++ b/src/main/java/com/samyookgoo/palgoosam/auction/service/AuctionService.java
@@ -566,6 +566,7 @@ public class AuctionService {
         auction.setStatus(AuctionStatus.deleted);
         auction.setIsDeleted(true);
         auctionRepository.save(auction);
+        this.auctionSearchElasticsearchRepository.deleteById(auctionId.toString());
     }
 
     private void softDeleteAuctionImages(Long auctionId) {

--- a/src/main/java/com/samyookgoo/palgoosam/auction/service/AuctionService.java
+++ b/src/main/java/com/samyookgoo/palgoosam/auction/service/AuctionService.java
@@ -82,6 +82,7 @@ public class AuctionService {
     private final AuctionSearchRepository auctionSearchRepository;
     private final AuctionSearchElasticsearchRepository auctionSearchElasticsearchRepository;
     private final ElasticsearchOperations elasticsearchOperations;
+    private final CategoryService categoryService;
     //    private final S3Service s3Service;
 //    private final StringRedisTemplate stringRedisTemplate;
 
@@ -106,12 +107,33 @@ public class AuctionService {
         LocalDateTime endTime = startTime.plusMinutes(request.getDurationTime());
 
         Auction auction = Auction.from(request, category, user, startTime, endTime);
-        auctionRepository.save(auction);
+        Auction savedAuction = auctionRepository.save(auction);
 
 //        setRedisStartTrigger(auction.getId(), auction.getStartTime());
 //        setRedisEndTrigger(auction.getId(), auction.getEndTime());
 
         List<AuctionImageResponse> imageResponses = saveAuctionImages(request.getImages(), auction);
+
+        //ES 등록 및 등록을 위한 데이터 확인
+        List<Long> ancestorIds = categoryService.collectAncestorIds(category);
+
+        AuctionSearchDocument searchDocument = new AuctionSearchDocument(
+                savedAuction.getId().toString(),
+                savedAuction.getTitle(),
+                savedAuction.getDescription(),
+                ancestorIds,
+                savedAuction.getItemCondition().toString(),
+                savedAuction.getStatus().toString(),
+                savedAuction.getBasePrice(),
+                savedAuction.getBasePrice(),
+                0L,
+                0L,
+                savedAuction.getCreatedAt(),
+                savedAuction.getStartTime(),
+                savedAuction.getEndTime(),
+                imageResponses.getFirst().getUrl()
+        );
+        this.auctionSearchElasticsearchRepository.save(searchDocument);
 
         return AuctionCreateResponse.of(auction, imageResponses, category,
                 request.getStartDelay(), request.getDurationTime());

--- a/src/main/java/com/samyookgoo/palgoosam/auction/service/CategoryService.java
+++ b/src/main/java/com/samyookgoo/palgoosam/auction/service/CategoryService.java
@@ -3,6 +3,8 @@ package com.samyookgoo.palgoosam.auction.service;
 import com.samyookgoo.palgoosam.auction.domain.Category;
 import com.samyookgoo.palgoosam.auction.dto.response.CategoryResponseDto;
 import com.samyookgoo.palgoosam.auction.repository.CategoryRepository;
+
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -25,5 +27,15 @@ public class CategoryService {
             responseDto.setParentId(category.getParent() != null ? category.getParent().getId() : null);
             return responseDto;
         }).toList();
+    }
+
+    public List<Long> collectAncestorIds(Category category) {
+        List<Long> ids = new ArrayList<>();
+        Category current = category;
+        while (current != null) {
+            ids.add(current.getId());
+            current = current.getParent();
+        }
+        return ids;
     }
 }

--- a/src/main/java/com/samyookgoo/palgoosam/search/domain/AuctionSearchDocument.java
+++ b/src/main/java/com/samyookgoo/palgoosam/search/domain/AuctionSearchDocument.java
@@ -1,5 +1,7 @@
 package com.samyookgoo.palgoosam.search.domain;
 
+import com.samyookgoo.palgoosam.auction.constant.AuctionStatus;
+import com.samyookgoo.palgoosam.auction.constant.ItemCondition;
 import com.samyookgoo.palgoosam.auction.domain.Category;
 import jakarta.persistence.Id;
 import lombok.Getter;
@@ -61,4 +63,21 @@ public class AuctionSearchDocument {
     // 검색 결과 표시용
     @Field(name = "thumbnail_url", type = FieldType.Keyword, index = false)  // 검색 안함
     private String thumbnailUrl;
+
+    public AuctionSearchDocument(String id, String title, String description, List<Long> categoryId, String itemCondition, String status, Integer basePrice, Integer currentPrice, Long bidderCount, Long scrapCount, LocalDateTime createdAt, LocalDateTime startTime, LocalDateTime endTime, String thumbnailUrl) {
+        this.id = id;
+        this.title = title;
+        this.description = description;
+        this.categoryId = categoryId;
+        this.itemCondition = itemCondition;
+        this.status = status;
+        this.basePrice = basePrice;
+        this.currentPrice = currentPrice;
+        this.bidderCount = bidderCount;
+        this.scrapCount = scrapCount;
+        this.createdAt = createdAt;
+        this.startTime = startTime;
+        this.endTime = endTime;
+        this.thumbnailUrl = thumbnailUrl;
+    }
 }

--- a/src/main/java/com/samyookgoo/palgoosam/search/domain/AuctionSearchDocument.java
+++ b/src/main/java/com/samyookgoo/palgoosam/search/domain/AuctionSearchDocument.java
@@ -5,10 +5,7 @@ import com.samyookgoo.palgoosam.auction.constant.ItemCondition;
 import com.samyookgoo.palgoosam.auction.domain.Category;
 import jakarta.persistence.Id;
 import lombok.Getter;
-import org.springframework.data.elasticsearch.annotations.Document;
-import org.springframework.data.elasticsearch.annotations.Field;
-import org.springframework.data.elasticsearch.annotations.FieldType;
-import org.springframework.data.elasticsearch.annotations.Setting;
+import org.springframework.data.elasticsearch.annotations.*;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -51,13 +48,13 @@ public class AuctionSearchDocument {
     @Field(name = "scrap_count", type = FieldType.Long)
     private Long scrapCount;
 
-    @Field(name = "created_at", type = FieldType.Date, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    @Field(name = "created_at", type = FieldType.Date, format = DateFormat.date_hour_minute_second, pattern = "yyyy-MM-dd'T'HH:mm:ss")
     private LocalDateTime createdAt;
 
-    @Field(name = "start_time", type = FieldType.Date, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    @Field(name = "start_time", type = FieldType.Date, format = DateFormat.date_hour_minute_second, pattern = "yyyy-MM-dd'T'HH:mm:ss")
     private LocalDateTime startTime;
 
-    @Field(name = "end_time", type = FieldType.Date, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    @Field(name = "end_time", type = FieldType.Date, format = DateFormat.date_hour_minute_second, pattern = "yyyy-MM-dd'T'HH:mm:ss")
     private LocalDateTime endTime;
 
     // 검색 결과 표시용


### PR DESCRIPTION
### ✅  PR Type

- [ ] 버그수정(Bugfix)
- [x] 기능개발(Feature)
- [ ] 코드 스타일 변경(Code style update) (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경
- [ ] 문서 내용 변경
- [ ] Other… Please describe:

### 🎯요약(Summary)
- 엘라스틱서치 도입으로 MySQL과의 데이터 동기화 로직 추가(create, delete만 추가)

### 💻 상세 내용(Describe your changes)
1. 작업 배경
MySQL에 등록되는 Auction의 데이터를 엘라스틱서치에도 도입해야 하는 상황이 발생했습니다.
일단은 create, delete 레벨에서 동작하도록 코드를 작성했습니다. 
update는 입찰이나 스크랩 등이 추가되는 시나리오에서 복잡해질 것 같아서, 좀 더 고민이 필요한 내용이라 생각했습니다.

2. 상세 작업
가장 직관적인 dual write 방식으로 구현했습니다.
MySQL에 데이터를 쓰고 성공한다면 엘라스틱서치에 데이터를 쓰는 방향입니다.

3. 개선이 필요한 사항 1 - 트랜잭션에서 ES 등록 분리
`@Transactional` 어노테이션이 붙은, 트랜잭션 내부에서 MySQL과 엘라스틱서치 모두에 쓰기 때문에 DB 커넥션을 오래 소유하게 됩니다.
가장 쉽게 생각할 수 있는 부작용은 많은 요청이 들어올 때, DB 커넥션을 오래 소유하면서 커넥션 풀 고갈이 되는 것입니다.
실제로 Toxiproxy라는 네트워크 지연 시나리오를 만들 수 있는 도구로 차이를 비교해보면, 2초의 지연 시간을 추가하면 제 컴퓨터 기준 500ms에서 4초 정도로 api 응답이 늦어지게 됩니다.

[지연 시간 X]
<img width="912" height="823" alt="image" src="https://github.com/user-attachments/assets/757fba5d-341b-4816-977d-ca916d9229a0" />

[지연 시간 O]
<img width="944" height="827" alt="image" src="https://github.com/user-attachments/assets/5fdda178-cd59-48d7-b071-92dd2b07151b" />

다음 작업은 스프링 이벤트의 `@TransactionalEventListener`를 활용해서 커밋 이후에 이벤트가 발행되도록 시도할 예정입니다.

### 📌 관련 이슈번호(Related Issue)
- #2