### PR TITLE
Feat:es transaction event

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -124,6 +124,10 @@ dependencies {
 
     //h2
     runtimeOnly 'com.h2database:h2'
+
+    // Flyway 추가
+    implementation 'org.flywaydb:flyway-core'
+    implementation 'org.flywaydb:flyway-mysql'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/samyookgoo/palgoosam/PalgoosamApplication.java
+++ b/src/main/java/com/samyookgoo/palgoosam/PalgoosamApplication.java
@@ -2,8 +2,10 @@ package com.samyookgoo.palgoosam;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableAsync
 @EnableScheduling
 @SpringBootApplication
 public class PalgoosamApplication {

--- a/src/main/java/com/samyookgoo/palgoosam/auction/constant/EventStatus.java
+++ b/src/main/java/com/samyookgoo/palgoosam/auction/constant/EventStatus.java
@@ -1,0 +1,8 @@
+package com.samyookgoo.palgoosam.auction.constant;
+
+public enum EventStatus {
+    PENDING,
+    PROCESSED,
+    FAILED,
+    DEAD
+}

--- a/src/main/java/com/samyookgoo/palgoosam/auction/constant/EventType.java
+++ b/src/main/java/com/samyookgoo/palgoosam/auction/constant/EventType.java
@@ -1,0 +1,6 @@
+package com.samyookgoo.palgoosam.auction.constant;
+
+public enum EventType {
+    AUCTION_CREATED,
+    AUCTION_UPDATED
+}

--- a/src/main/java/com/samyookgoo/palgoosam/auction/domain/AuctionOutbox.java
+++ b/src/main/java/com/samyookgoo/palgoosam/auction/domain/AuctionOutbox.java
@@ -1,0 +1,73 @@
+package com.samyookgoo.palgoosam.auction.domain;
+
+import com.samyookgoo.palgoosam.auction.constant.EventStatus;
+import com.samyookgoo.palgoosam.auction.constant.EventType;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+import jakarta.persistence.Id;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "auction_outbox")
+@Entity
+public class AuctionOutbox {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "aggregate_type", nullable = false, length = 100)
+    private String aggregateType;
+
+    @Column(name = "auction_id", nullable = false)
+    private Long auctionId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "event_type", nullable = false, length = 50)
+    private EventType eventType;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "event_status", nullable = false, length = 50)
+    private EventStatus eventStatus;
+
+    @Builder.Default
+    @Column(name = "retry_count", nullable = false)
+    private Long retryCount = 0L;
+
+    @CreationTimestamp
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    private LocalDateTime updatedAt;
+
+    @Column(name = "processed_at")
+    private LocalDateTime processedAt;
+
+    public AuctionOutbox(String aggregateType, Long auctionId, EventType eventType, EventStatus eventStatus) {
+        this.aggregateType = aggregateType;
+        this.auctionId = auctionId;
+        this.eventType = eventType;
+        this.eventStatus = eventStatus;
+        this.retryCount = 0L;
+    }
+
+    public void processEvent() {
+        this.eventStatus = EventStatus.PROCESSED;
+        this.processedAt = LocalDateTime.now();
+    }
+
+    private static final Long MAX_RETRY_COUNT = 5L;
+
+    public void incrementRetryCount() {
+        this.retryCount++;
+        if (this.retryCount >= MAX_RETRY_COUNT) {
+            this.eventStatus = EventStatus.DEAD;
+        }
+    }
+}

--- a/src/main/java/com/samyookgoo/palgoosam/auction/event/ElasticsearchAuctionEvent.java
+++ b/src/main/java/com/samyookgoo/palgoosam/auction/event/ElasticsearchAuctionEvent.java
@@ -4,11 +4,17 @@ import com.samyookgoo.palgoosam.search.domain.AuctionSearchDocument;
 
 public class ElasticsearchAuctionEvent {
     private final AuctionSearchDocument searchDocument;
+    private final Long outboxId;
 
-    public ElasticsearchAuctionEvent(AuctionSearchDocument searchDocument) {
+    public ElasticsearchAuctionEvent(AuctionSearchDocument searchDocument, Long outboxId) {
         this.searchDocument = searchDocument;
+        this.outboxId = outboxId;
     }
 
     public AuctionSearchDocument getSearchDocument() {
         return searchDocument;
-    }}
+    }
+    public Long getOutboxId() {
+        return outboxId;
+    }
+}

--- a/src/main/java/com/samyookgoo/palgoosam/auction/event/ElasticsearchAuctionEvent.java
+++ b/src/main/java/com/samyookgoo/palgoosam/auction/event/ElasticsearchAuctionEvent.java
@@ -1,0 +1,14 @@
+package com.samyookgoo.palgoosam.auction.event;
+
+import com.samyookgoo.palgoosam.search.domain.AuctionSearchDocument;
+
+public class ElasticsearchAuctionEvent {
+    private final AuctionSearchDocument searchDocument;
+
+    public ElasticsearchAuctionEvent(AuctionSearchDocument searchDocument) {
+        this.searchDocument = searchDocument;
+    }
+
+    public AuctionSearchDocument getSearchDocument() {
+        return searchDocument;
+    }}

--- a/src/main/java/com/samyookgoo/palgoosam/auction/event/ElasticsearchAuctionOutboxEvent.java
+++ b/src/main/java/com/samyookgoo/palgoosam/auction/event/ElasticsearchAuctionOutboxEvent.java
@@ -1,0 +1,21 @@
+package com.samyookgoo.palgoosam.auction.event;
+
+import com.samyookgoo.palgoosam.auction.constant.EventType;
+
+public class ElasticsearchAuctionOutboxEvent {
+    private Long auctionId;
+    private EventType eventType;
+
+    public ElasticsearchAuctionOutboxEvent(Long auctionId, EventType eventType) {
+        this.auctionId = auctionId;
+        this.eventType = eventType;
+    }
+
+    public Long getAuctionId() {
+        return auctionId;
+    }
+
+    public EventType getEventType() {
+        return eventType;
+    }
+}

--- a/src/main/java/com/samyookgoo/palgoosam/auction/event_listener/AuctionEventListener.java
+++ b/src/main/java/com/samyookgoo/palgoosam/auction/event_listener/AuctionEventListener.java
@@ -1,0 +1,22 @@
+package com.samyookgoo.palgoosam.auction.event_listener;
+
+import com.samyookgoo.palgoosam.auction.event.ElasticsearchAuctionEvent;
+import com.samyookgoo.palgoosam.search.repository.AuctionSearchElasticsearchRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class AuctionEventListener {
+
+    private final AuctionSearchElasticsearchRepository auctionSearchElasticsearchRepository;
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onAuctionCreated(ElasticsearchAuctionEvent event) {
+        auctionSearchElasticsearchRepository.save(event.getSearchDocument());
+    }
+}

--- a/src/main/java/com/samyookgoo/palgoosam/auction/event_listener/AuctionEventListener.java
+++ b/src/main/java/com/samyookgoo/palgoosam/auction/event_listener/AuctionEventListener.java
@@ -1,22 +1,34 @@
 package com.samyookgoo.palgoosam.auction.event_listener;
 
+import com.samyookgoo.palgoosam.auction.domain.AuctionOutbox;
 import com.samyookgoo.palgoosam.auction.event.ElasticsearchAuctionEvent;
+import com.samyookgoo.palgoosam.auction.repository.AuctionOutboxRepository;
+import com.samyookgoo.palgoosam.search.domain.AuctionSearchDocument;
 import com.samyookgoo.palgoosam.search.repository.AuctionSearchElasticsearchRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
+
+import static org.springframework.transaction.annotation.Propagation.REQUIRES_NEW;
 
 @Component
 @RequiredArgsConstructor
 public class AuctionEventListener {
 
     private final AuctionSearchElasticsearchRepository auctionSearchElasticsearchRepository;
+    private final AuctionOutboxRepository auctionOutboxRepository;
+    private final String AGGREGATE_TYPE = "auction";
 
     @Async
+    @Transactional(propagation = REQUIRES_NEW)
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void onAuctionCreated(ElasticsearchAuctionEvent event) {
-        auctionSearchElasticsearchRepository.save(event.getSearchDocument());
+        AuctionSearchDocument saved = auctionSearchElasticsearchRepository.save(event.getSearchDocument());
+        AuctionOutbox auctionOutbox = auctionOutboxRepository.getAuctionOutboxById(event.getOutboxId());
+        auctionOutbox.processEvent();
+        auctionOutboxRepository.save(auctionOutbox);
     }
 }

--- a/src/main/java/com/samyookgoo/palgoosam/auction/repository/AuctionOutboxRepository.java
+++ b/src/main/java/com/samyookgoo/palgoosam/auction/repository/AuctionOutboxRepository.java
@@ -1,0 +1,13 @@
+package com.samyookgoo.palgoosam.auction.repository;
+
+import com.samyookgoo.palgoosam.auction.constant.EventStatus;
+import com.samyookgoo.palgoosam.auction.domain.AuctionOutbox;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface AuctionOutboxRepository extends JpaRepository<AuctionOutbox, Long> {
+    AuctionOutbox getAuctionOutboxById(Long id);
+
+    List<AuctionOutbox> findByEventStatusAndRetryCountLessThan(EventStatus eventStatus, Long maxRetryCount);
+}

--- a/src/main/java/com/samyookgoo/palgoosam/auction/scheduler/AuctionOutboxScheduler.java
+++ b/src/main/java/com/samyookgoo/palgoosam/auction/scheduler/AuctionOutboxScheduler.java
@@ -1,0 +1,76 @@
+package com.samyookgoo.palgoosam.auction.scheduler;
+
+import com.samyookgoo.palgoosam.auction.constant.EventStatus;
+import com.samyookgoo.palgoosam.auction.domain.Auction;
+import com.samyookgoo.palgoosam.auction.domain.AuctionImage;
+import com.samyookgoo.palgoosam.auction.domain.AuctionOutbox;
+import com.samyookgoo.palgoosam.auction.repository.AuctionImageRepository;
+import com.samyookgoo.palgoosam.auction.repository.AuctionOutboxRepository;
+import com.samyookgoo.palgoosam.auction.repository.AuctionRepository;
+import com.samyookgoo.palgoosam.auction.service.CategoryService;
+import com.samyookgoo.palgoosam.search.domain.AuctionSearchDocument;
+import com.samyookgoo.palgoosam.search.repository.AuctionSearchElasticsearchRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class AuctionOutboxScheduler {
+
+    private static final Long MAX_RETRY_COUNT = 5L;
+
+    private final AuctionOutboxRepository auctionOutboxRepository;
+    private final AuctionRepository auctionRepository;
+    private final CategoryService categoryService;
+    private final AuctionImageRepository auctionImageRepository;
+    private final AuctionSearchElasticsearchRepository auctionSearchElasticsearchRepository;
+
+    @Scheduled(fixedDelay = 60000)
+    @Transactional
+    public void processAuctionCreationEvent() {
+        List<AuctionOutbox> pendingOutboxes = auctionOutboxRepository
+                .findByEventStatusAndRetryCountLessThan(EventStatus.PENDING, MAX_RETRY_COUNT);
+
+        for (AuctionOutbox auctionOutbox : pendingOutboxes) {
+            try {
+                Auction auction = auctionRepository
+                        .findById(auctionOutbox.getAuctionId())
+                        .orElseThrow();
+
+                List<Long> ancestorIds = categoryService
+                        .collectAncestorIds(auction.getCategory());
+
+                List<AuctionImage> images = auctionImageRepository
+                        .findByAuctionId(auctionOutbox.getAuctionId());
+
+                AuctionSearchDocument searchDocument = new AuctionSearchDocument(
+                        auction.getId().toString(),
+                        auction.getTitle(),
+                        auction.getDescription(),
+                        ancestorIds,
+                        auction.getItemCondition().toString(),
+                        auction.getStatus().toString(),
+                        auction.getBasePrice(),
+                        auction.getBasePrice(),
+                        0L,
+                        0L,
+                        auction.getCreatedAt(),
+                        auction.getStartTime(),
+                        auction.getEndTime(),
+                        images.getFirst().getUrl()
+                );
+
+                auctionSearchElasticsearchRepository.save(searchDocument);
+                auctionOutbox.processEvent();
+            } catch (Exception e) {
+                auctionOutbox.incrementRetryCount();
+            } finally {
+                auctionOutboxRepository.save(auctionOutbox);
+            }
+        }
+    }
+}

--- a/src/main/java/com/samyookgoo/palgoosam/auction/service/AuctionService.java
+++ b/src/main/java/com/samyookgoo/palgoosam/auction/service/AuctionService.java
@@ -3,11 +3,10 @@ package com.samyookgoo.palgoosam.auction.service;
 import co.elastic.clients.elasticsearch._types.FieldValue;
 import co.elastic.clients.elasticsearch._types.query_dsl.*;
 import com.samyookgoo.palgoosam.auction.constant.AuctionStatus;
+import com.samyookgoo.palgoosam.auction.constant.EventStatus;
+import com.samyookgoo.palgoosam.auction.constant.EventType;
 import com.samyookgoo.palgoosam.auction.constant.ItemCondition;
-import com.samyookgoo.palgoosam.auction.domain.Auction;
-import com.samyookgoo.palgoosam.auction.domain.AuctionImage;
-import com.samyookgoo.palgoosam.auction.domain.AuctionSearchProjection;
-import com.samyookgoo.palgoosam.auction.domain.Category;
+import com.samyookgoo.palgoosam.auction.domain.*;
 import com.samyookgoo.palgoosam.auction.dto.AuctionSearchResultDto;
 import com.samyookgoo.palgoosam.auction.dto.request.AuctionCreateRequest;
 import com.samyookgoo.palgoosam.auction.dto.request.AuctionImageRequest;
@@ -22,10 +21,7 @@ import com.samyookgoo.palgoosam.auction.exception.AuctionInvalidStateException;
 import com.samyookgoo.palgoosam.auction.exception.AuctionNotFoundException;
 import com.samyookgoo.palgoosam.auction.exception.AuctionUpdateLockedException;
 import com.samyookgoo.palgoosam.auction.exception.CategoryNotFoundException;
-import com.samyookgoo.palgoosam.auction.repository.AuctionImageRepository;
-import com.samyookgoo.palgoosam.auction.repository.AuctionRepository;
-import com.samyookgoo.palgoosam.auction.repository.AuctionSearchRepository;
-import com.samyookgoo.palgoosam.auction.repository.CategoryRepository;
+import com.samyookgoo.palgoosam.auction.repository.*;
 import com.samyookgoo.palgoosam.auction.service.dto.AuctionSearchDto;
 import com.samyookgoo.palgoosam.auth.service.AuthService;
 import com.samyookgoo.palgoosam.bid.domain.Bid;
@@ -83,6 +79,7 @@ public class AuctionService {
     private final PaymentRepository paymentRepository;
     private final AuctionSearchRepository auctionSearchRepository;
     private final AuctionSearchElasticsearchRepository auctionSearchElasticsearchRepository;
+    private final AuctionOutboxRepository auctionOutboxRepository;
     private final ElasticsearchOperations elasticsearchOperations;
     private final CategoryService categoryService;
     private final ApplicationEventPublisher publisher;
@@ -94,6 +91,8 @@ public class AuctionService {
 
     //    @Value("${cloud.aws.region.static}")
     private String region = "test";
+
+    private final String AGGREGATE_TYPE = "auction";
 
     @Transactional
     public AuctionCreateResponse createAuction(AuctionCreateRequest request) {
@@ -136,12 +135,13 @@ public class AuctionService {
                 savedAuction.getEndTime(),
                 imageResponses.getFirst().getUrl()
         );
-        publisher.publishEvent(new ElasticsearchAuctionEvent(searchDocument));
+        AuctionOutbox auctionOutbox = new AuctionOutbox(AGGREGATE_TYPE, savedAuction.getId(), EventType.AUCTION_CREATED, EventStatus.PENDING);
+        auctionOutboxRepository.save(auctionOutbox);
+        publisher.publishEvent(new ElasticsearchAuctionEvent(searchDocument, auctionOutbox.getId()));
 
         return AuctionCreateResponse.of(auction, imageResponses, category,
                 request.getStartDelay(), request.getDurationTime());
     }
-
 
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/samyookgoo/palgoosam/auction/service/AuctionService.java
+++ b/src/main/java/com/samyookgoo/palgoosam/auction/service/AuctionService.java
@@ -14,6 +14,7 @@ import com.samyookgoo.palgoosam.auction.dto.request.AuctionImageRequest;
 import com.samyookgoo.palgoosam.auction.dto.request.AuctionSearchRequestDto;
 import com.samyookgoo.palgoosam.auction.dto.request.AuctionUpdateRequest;
 import com.samyookgoo.palgoosam.auction.dto.response.*;
+import com.samyookgoo.palgoosam.auction.event.ElasticsearchAuctionEvent;
 import com.samyookgoo.palgoosam.auction.exception.AuctionCategoryException;
 import com.samyookgoo.palgoosam.auction.exception.AuctionForbiddenException;
 import com.samyookgoo.palgoosam.auction.exception.AuctionImageException;
@@ -59,6 +60,7 @@ import lombok.extern.slf4j.Slf4j;
 //import org.springframework.beans.factory.annotation.Value;
 //import org.springframework.data.redis.core.RedisTemplate;
 //import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.elasticsearch.client.elc.NativeQuery;
@@ -83,6 +85,7 @@ public class AuctionService {
     private final AuctionSearchElasticsearchRepository auctionSearchElasticsearchRepository;
     private final ElasticsearchOperations elasticsearchOperations;
     private final CategoryService categoryService;
+    private final ApplicationEventPublisher publisher;
     //    private final S3Service s3Service;
 //    private final StringRedisTemplate stringRedisTemplate;
 
@@ -133,11 +136,13 @@ public class AuctionService {
                 savedAuction.getEndTime(),
                 imageResponses.getFirst().getUrl()
         );
-        this.auctionSearchElasticsearchRepository.save(searchDocument);
+        publisher.publishEvent(new ElasticsearchAuctionEvent(searchDocument));
 
         return AuctionCreateResponse.of(auction, imageResponses, category,
                 request.getStartDelay(), request.getDurationTime());
     }
+
+
 
     @Transactional(readOnly = true)
     public AuctionDetailResponse getAuctionDetail(Long auctionId) {

--- a/src/main/resources/db/migration/V2__Create_auction_outbox_table.sql
+++ b/src/main/resources/db/migration/V2__Create_auction_outbox_table.sql
@@ -1,0 +1,13 @@
+CREATE TABLE `auction_outbox`
+(
+    `id`             BIGINT       NOT NULL AUTO_INCREMENT,
+    `aggregate_type` VARCHAR(100) NOT NULL,
+    `auction_id`     BIGINT       NOT NULL,
+    `event_type`     VARCHAR(50)  NOT NULL,
+    `event_status`   VARCHAR(50)  NOT NULL,
+    `retry_count`    BIGINT       NOT NULL DEFAULT 0,
+    `created_at`     DATETIME(6)  NOT NULL,
+    `updated_at`     DATETIME(6),
+    `processed_at`   DATETIME(6),
+    PRIMARY KEY (`id`)
+);


### PR DESCRIPTION
### ✅  PR Type
- [ ] 버그수정(Bugfix)
- [x] 기능개발(Feature)
- [ ] 코드 스타일 변경(Code style update) (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경
- [ ] 문서 내용 변경
- [ ] Other… Please describe:

### 🎯요약(Summary)

- 경매 등록 시 비동기적으로 엘라스틱서치와 MySQL 데이터 동기화 적용
- 이벤트 정합성을 보장하기 위한 트랜잭셔널 아웃박스 패턴 도입
- 스케줄링을 적용해서 엘라스틱서치와의 네트워크 장애 복구 시 이벤트가 실행될 수 있도록 구현

### 💻 상세 내용(Describe your changes)
1. 왜 비동기적으로 데이터 동기화를 분리해야 하는가?

toxiproxy라는 네트워크 장애 시나리오를 도와주는 도구가 있습니다.
해당 도구를 활용하여 엘라스틱서치가 동작하는 컨테이너에 지연을 생성했습니다.

**<API 응답 결과>**
<img width="951" height="823" alt="image" src="https://github.com/user-attachments/assets/c932d248-3827-4f8d-bad0-a2fa625e0fe7" />
위 결과를 확인하면 API 응답에서 4초의 시간이 소모됨을 확인할 수 있습니다. 
단순하게 사용자 응답 시간이 길어지는 것도 문제지만,
수정 전 코드에서는 `@Transactional` 어노테이션이 적용되어 응답 시간이 길어질수록 트랜잭션을 오래 소유하게 됩니다.
그래서 서버 리소스를 더 빠르게 고갈시킬 수 있는 원인이 될 수 있었습니다.

따라서 `@Async`와 `@TransactionalEventListener’를 활용하여 MySQL 트랜잭션 커밋 이후 Spring Event 기반 비동기로 처리할 수 있도록 코드를 수정했습니다. 

2. 트랜잭셔널 아웃박스 패턴이 왜 필요한가?

엘라스틱서치와의 통신 자체에 실패하는 경우를 확장하여 고려했습니다.
**<API 응답 결과>**
<img width="923" height="653" alt="image" src="https://github.com/user-attachments/assets/8afcb643-f04a-4dfb-b6e4-4b22d948f295" />
API 응답 자체는 350ms 정도로 빠르게 받을 수 있었습니다.

**<RDBMS(MySQL) 데이터 쓰기 결과>**
<img width="343" height="141" alt="image" src="https://github.com/user-attachments/assets/97d5e1e5-f9a7-487e-aec1-94f592f4faba" />

**<엘라스틱서치와의 통신 실패로 데이터가 안 써진 경우>**
<img width="247" height="247" alt="image" src="https://github.com/user-attachments/assets/15200761-a88e-41f0-80dc-8648a75e7602" />

위 2가지 결과를 보면 MySQL은 2550818개의 경매가 등록되어 있고, 
엘라스틱서치는 2550817개의 경매가 등록되어 정합성이 깨짐을 확인할 수 있습니다.
네트워크 요청 지연이 너무 길어서 spring의 timeout 예외가 터지거나 엘라스틱서치 컨테이너가 내려가는 등의 시나리오에서 발생할 수 있는 결과입니다.

이런 현상을 보완하기 위해서 트랜잭셔널 아웃박스 패턴과 Change Data Capture를 고려했습니다.

경매 등록이라는 단일 진입점이 명확하고 수 초의 지연이 허용되는 상황이라 가정하에, 
애플리케이션 코드와 무관한 변경 캡처, 실시간에 가까운 동기화라는 CDC의 장점보다 인프라 구성과 운영 부담이 더 커질 것이라 생각했습니다.

트랜잭셔널 아웃박스 패턴은 MySQL과 스케줄러만으로 구현 가능하기 때문에 현재 인프라 범위 내에서 해결하며 정합성을 챙길 수 있는 방법이라 생각하고, 도입했습니다.

3. flyway는 왜 도입했나요?

트랜잭셔널 아웃박스 패턴을 적용하며 이벤트 발행 및 소비 과정을 RDBMS에 써야할 요구사항이 생겼고, 아래와 같은 이유로 flyway를 사용했습니다.
- 스키마 변경 이력을 확인 가능
- 환경 간 불일치 해소(dev, staging, production)
- CI/CD 과정에서 자동으로 DB 변경이 적용
- 협업 시 디스코드나 슬랙으로 일일이 DDL 명령어를 공유할 필요성이 낮아짐

### 📌 관련 이슈번호(Related Issue)
- close #2 